### PR TITLE
Remove "MensaZH" from the AppBar when on a detail screen

### DIFF
--- a/app/src/main/java/ch/florianfrauenfelder/mensazh/ui/main/MainScreen.kt
+++ b/app/src/main/java/ch/florianfrauenfelder/mensazh/ui/main/MainScreen.kt
@@ -112,9 +112,7 @@ fun MainScreen(
       TopAppBar(
         title = {
           Text(
-            text = "${stringResource(R.string.app_name)}${
-              navigator.currentDestination?.contentKey?.mensa?.title ?: ""
-            }",
+            text = navigator.currentDestination?.contentKey?.mensa?.title ?: stringResource(R.string.app_name),
           )
         },
         navigationIcon = {


### PR DESCRIPTION
When the user is on a detail screen, I noticed that the app bar title was quite crowded and the app title was mushed together with the Mensa name.

Now, "MensaZH" only shows when viewing the main screen and the Mensa name is displayed alone when looking at the available menus. Another option would have been to have the app title and the Mensa name in the detail screen, like for example **MensaZH: Archimedes**. But on smaller screens, this more easily leads to line breaking, which doesn't look nice.
<img width="1280" height="2856" alt="Screenshot_20251123_111431" src="https://github.com/user-attachments/assets/c7b2ba38-d15c-4ceb-bc97-d073b129cf2e" />
